### PR TITLE
DEV: Update plugin name to match repo name.

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# name: discourse-amazon-sns-pns
+# name: discourse-amazon-sns
 # about: Enables push notifications via Amazon SNS. To be used in conjunction with a mobile app.
 # version: 0.1
 # authors: Penar Musaraj


### PR DESCRIPTION
Removes a console warning as well: 

```
Plugin name is 'discourse-amazon-sns-pns', but plugin directory is named 'discourse-amazon-sns'
```