### PR TITLE
DEV: Add optional `use_title_and_body_for_ios` param

### DIFF
--- a/lib/amazon_sns_helper.rb
+++ b/lib/amazon_sns_helper.rb
@@ -57,6 +57,10 @@ class AmazonSnsHelper
     message = generate_message(payload, user)
     url = "#{Discourse.base_url_no_prefix}#{payload[:post_url]}"
 
+    message = { title: payload[:title], body: payload[:body] } if payload[
+      :use_title_and_body_for_ios
+    ]
+
     iphone_notification = { aps: { alert: message, badge: unread }, url: url }
 
     sns_payload = {


### PR DESCRIPTION
When creating an IOS push notification, utilizing: 

```rb
aps: { alert: message }
```
tells IOS to default to using the App name as the bolded header of the notification. This is a fine default, but in cases where we want to pass custom content as the bolded header of a notification, we don't have a way to do that with our current setup. 

This PR introduces an optional `use_title_and_body_for_ios` param, which can be added to the payload. When accompanied by `title` and `body` (also in the payload), the `title` will be used as the bolded header, and the `body` as the content. 

eg.

```rb
payload: {
   use_title_and_body_for_ios: true,
   title: "hi",
   body: "bye",
}
```
Results in: 

<img width="326" alt="Screenshot 2025-07-08 at 12 52 00 PM" src="https://github.com/user-attachments/assets/31f7577c-0ca8-4d04-808f-7c420479dbfc" />

