### PR TITLE
DEV: Update Amazon_sns_helper publish_android method

### DIFF
--- a/lib/amazon_sns_helper.rb
+++ b/lib/amazon_sns_helper.rb
@@ -57,9 +57,7 @@ class AmazonSnsHelper
     message = generate_message(payload, user)
     url = "#{Discourse.base_url_no_prefix}#{payload[:post_url]}"
 
-    message = { title: payload[:title], body: payload[:body] } if payload[
-      :use_title_and_body_for_ios
-    ]
+    message = { title: payload[:title], body: payload[:body] } if payload[:use_title_and_body]
 
     iphone_notification = { aps: { alert: message, badge: unread }, url: url }
 
@@ -91,19 +89,34 @@ class AmazonSnsHelper
   end
 
   def self.publish_android(user, target_arn, payload)
-    message = generate_message(payload, user)
-
     url = "#{Discourse.base_url_no_prefix}#{payload[:post_url]}"
-    android_notification = {
-      data: {
-        message: message,
-        url: url,
-      },
-      notification: {
-        title: payload[:topic_title] || payload[:translated_title],
-        body: message,
-      },
-    }
+
+    android_notification =
+      if payload[:use_title_and_body]
+        {
+          data: {
+            message: payload[:body],
+            url: url,
+          },
+          notification: {
+            title: payload[:title],
+            body: payload[:body],
+          },
+        }
+      else
+        message = generate_message(payload, user)
+
+        {
+          data: {
+            message: message,
+            url: url,
+          },
+          notification: {
+            title: payload[:topic_title] || payload[:translated_title],
+            body: message,
+          },
+        }
+      end
 
     sns_payload = { gcm: android_notification.to_json }
 

--- a/spec/lib/amazon_sns_helper_spec.rb
+++ b/spec/lib/amazon_sns_helper_spec.rb
@@ -2,13 +2,14 @@
 
 RSpec.describe AmazonSnsHelper do
   fab!(:user)
+  let(:test_arn) { "sample:arn2" }
   let!(:subscription) do
     AmazonSnsSubscription.create!(
       user_id: user.id,
       device_token: "some_token",
       application_name: "application_name",
       platform: "ios",
-      endpoint_arn: "sample:arn2",
+      endpoint_arn: test_arn,
     )
   end
   let(:mock_response) { stub }
@@ -29,19 +30,19 @@ RSpec.describe AmazonSnsHelper do
       Aws::SNS::Client
         .any_instance
         .expects(:delete_endpoint)
-        .with(endpoint_arn: "sample:arn2")
+        .with(endpoint_arn: test_arn)
         .at_least(1)
     end
 
     it "disables the subscription and deletes the endpoint for publish_ios" do
-      described_class.publish_ios(user, "sample:arn2", {}, true)
+      described_class.publish_ios(user, test_arn, {}, true)
       subscription.reload
       expect(subscription.status).to eq(AmazonSnsSubscription.statuses[:disabled])
       expect(subscription.status_changed_at).not_to eq(nil)
     end
 
     it "disables the subscription and deletes the endpoint for publish_android" do
-      described_class.publish_android(user, "sample:arn2", {})
+      described_class.publish_android(user, test_arn, {})
       subscription.reload
       expect(subscription.status).to eq(AmazonSnsSubscription.statuses[:disabled])
       expect(subscription.status_changed_at).not_to eq(nil)
@@ -57,13 +58,87 @@ RSpec.describe AmazonSnsHelper do
     end
 
     it "destroys the subscription for publish_ios" do
-      described_class.publish_ios(user, "sample:arn2", {}, true)
+      described_class.publish_ios(user, test_arn, {}, true)
       expect(AmazonSnsSubscription.find_by(id: subscription.id)).to eq(nil)
     end
 
     it "destroys the subscription for publish_android" do
-      described_class.publish_android(user, "sample:arn2", {})
+      described_class.publish_android(user, test_arn, {})
       expect(AmazonSnsSubscription.find_by(id: subscription.id)).to eq(nil)
+    end
+  end
+
+  describe "publish_android" do
+    let(:client) { Aws::SNS::Client.new(stub_responses: true) }
+
+    before do
+      allow(described_class).to receive(:sns_client).and_return(client)
+      allow(client).to receive(:publish).and_return(mock_response)
+    end
+
+    context "when use_title_and_body is true" do
+      let(:payload) do
+        { use_title_and_body: true, title: "Test Title", body: "Test Body", post_url: "/test/url" }
+      end
+
+      it "uses title and body directly" do
+        described_class.publish_android(user, test_arn, payload)
+
+        expected_message = {
+          gcm: {
+            data: {
+              message: "Test Body",
+              url: "#{Discourse.base_url_no_prefix}/test/url",
+            },
+            notification: {
+              title: "Test Title",
+              body: "Test Body",
+            },
+          }.to_json,
+        }.to_json
+
+        expect(client).to have_received(:publish).with(
+          target_arn: test_arn,
+          message: expected_message,
+          message_structure: "json",
+        )
+      end
+    end
+
+    context "when use_title_and_body is false" do
+      let(:payload) do
+        {
+          topic_title: "Topic Title",
+          username: "username",
+          excerpt: "Excerpt",
+          post_url: "/test/url",
+        }
+      end
+
+      it "generates a message using topic title and excerpt" do
+        allow(described_class).to receive(:generate_message).and_return("@username: Excerpt")
+
+        described_class.publish_android(user, test_arn, payload)
+
+        expected_message = {
+          gcm: {
+            data: {
+              message: "@username: Excerpt",
+              url: "#{Discourse.base_url_no_prefix}/test/url",
+            },
+            notification: {
+              title: "Topic Title",
+              body: "@username: Excerpt",
+            },
+          }.to_json,
+        }.to_json
+
+        expect(client).to have_received(:publish).with(
+          target_arn: test_arn,
+          message: expected_message,
+          message_structure: "json",
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
## Changes

This PR updates the `publish_android` method in `amazon_sns_helper.rb` to use title and body from the payload.