### PR TITLE
FIX: Stop echoing SNS endpoint details in subscription responses

### DIFF
--- a/app/controllers/amazon_sns_controller.rb
+++ b/app/controllers/amazon_sns_controller.rb
@@ -63,7 +63,7 @@ class ::AmazonSnsSubscriptionController < ::ApplicationController
         status_changed_at: Time.zone.now,
       )
 
-      render_serialized(record, AmazonSnsSubscriptionSerializer, root: false)
+      render json: { id: record.id, status: record.status }
       return
     end
 

--- a/app/serializers/amazon_sns_subscription_serializer.rb
+++ b/app/serializers/amazon_sns_subscription_serializer.rb
@@ -3,10 +3,8 @@
 class AmazonSnsSubscriptionSerializer < ApplicationSerializer
   attributes :id,
              :user_id,
-             :device_token,
              :application_name,
              :platform,
-             :endpoint_arn,
              :created_at,
              :updated_at,
              :status,

--- a/spec/requests/amazon_sns_subscription_controller_spec.rb
+++ b/spec/requests/amazon_sns_subscription_controller_spec.rb
@@ -209,6 +209,42 @@ RSpec.describe AmazonSnsSubscriptionController do
   end
 
   describe "#disable" do
+    it "omits push endpoint details from token-based responses" do
+      token = "123123123123"
+
+      post "/amazon-sns/subscribe.json",
+           params: {
+             token: token,
+             application_name: "Penar's phone",
+             platform: "ios",
+           }
+
+      expect(response.status).to eq(200)
+      create_json = response.parsed_body
+      subscription = user.amazon_sns_subscriptions.find_by!(device_token: token)
+
+      expect(create_json.keys).to contain_exactly(
+        "id",
+        "user_id",
+        "application_name",
+        "platform",
+        "created_at",
+        "updated_at",
+        "status",
+        "status_changed_at",
+      )
+      expect(response.body).not_to include(subscription.device_token)
+      expect(response.body).not_to include(subscription.endpoint_arn)
+
+      post "/amazon-sns/disable.json", params: { token: token }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq(
+        "id" => subscription.id,
+        "status" => AmazonSnsSubscription.statuses[:disabled],
+      )
+    end
+
     it "marks a subscription as disabled" do
       post "/amazon-sns/subscribe.json",
            params: {


### PR DESCRIPTION
## Summary

This fixes an over-serialization bug in SNS subscription APIs. The subscription payload no longer includes device_token or endpoint_arn, and the token-based disable response now returns only id and status.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1227

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>